### PR TITLE
Updated README, pushed Chart Version

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0-alpha
+version: 0.1.1-alpha
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ s3:
     bucket: <myHotBucket>
 ```
 
+## To Do
+
+- [ ] Auto create persistentVolume for local cache
+- [ ] Add forget/prune CronJobs
+- [ ] Follow [helm charts best practises](https://helm.sh/docs/chart_best_practices/)
+
+
 ## Contributing
 
 Found a bug?


### PR DESCRIPTION
We need to publish a new Chart version because https://artifacthub.io/packages/helm/rustic/rustic pulls the information from the README in the released version, which still links to my private repo.
Added To Do in README.